### PR TITLE
fix(fzf): typo on the zero-width space unicode code point

### DIFF
--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -2,4 +2,4 @@ module edholm.dev/profzf/.sage
 
 go 1.20
 
-require go.einride.tech/sage v0.211.2
+require go.einride.tech/sage v0.212.0

--- a/.sage/go.sum
+++ b/.sage/go.sum
@@ -1,2 +1,2 @@
-go.einride.tech/sage v0.211.2 h1:eG08l527AEg66PnOPmUo0dbeNlIBkvnB32eHyX3y0Nc=
-go.einride.tech/sage v0.211.2/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=
+go.einride.tech/sage v0.212.0 h1:0v5rBRBA/v1lX4hxf0EDSOhPDi366VXAybxh4Rhqu7w=
+go.einride.tech/sage v0.212.0/go.mod h1:EzV5uciFX7/2ho8EKB5K9JghOfXIxlzs694b+Tkl5GQ=

--- a/README.md
+++ b/README.md
@@ -13,3 +13,30 @@ Usage
 Run `profzf server` to start the server. Use the `--project-dir` (can be specified multiple times) to specify the directories to scan for git repositories.
 
 Then run `profzf cd` to output an example command that uses `fzf` and `jq` to cd into the selected project.
+
+For example, I use it like this:
+
+```shell
+alias cdp='eval $(profzf cd)'
+```
+
+The server can be started by a systemd user service. Here is an example:
+
+```
+# ~/.config/systemd/user/profzf.service
+# systemctl --user enable --now profzf
+[Unit]
+Description=Starts profzf server
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=%h/go/bin/profzf server -p %h/code -p %h/go/src
+KillMode=process
+TimeoutSec=180
+
+[Install]
+WantedBy=default.target
+```
+
+*`%h` is the home directory*

--- a/cmd/profzf/command_cd.go
+++ b/cmd/profzf/command_cd.go
@@ -14,7 +14,7 @@ func newCdCommand() *cobra.Command {
 			const bin = "profzf"
 			fmt.Printf(
 				//nolint:lll
-				`cddir=$(%s list | fzf --delimiter $'\u201b' --nth 1 --tac --no-sort --preview 'git -C $(%s get -l -i=false {} | jq --raw-output .path) log -10' --preview-label="git log" |%s get -il - | jq --raw-output '.path') && cd "$cddir"`,
+				`cddir=$(%s list | fzf --delimiter $'\u200b' --nth 1 --tac --no-sort --preview 'git -C $(%s get -l -i=false {} | jq --raw-output .path) log -10' --preview-label="git log" |%s get -il - | jq --raw-output '.path') && cd "$cddir"`,
 				bin, bin, bin,
 			)
 		},


### PR DESCRIPTION
Made it so that you could filter on everything, not only the project name.